### PR TITLE
Rework how mails are sended after user account deletion - closes #35

### DIFF
--- a/app/config/config_test.yml
+++ b/app/config/config_test.yml
@@ -6,7 +6,7 @@ framework:
     session:
         storage_id: session.storage.mock_file
     profiler:
-        collect: false
+        collect: true
 
 web_profiler:
     toolbar: false

--- a/features/administrators/delete.feature
+++ b/features/administrators/delete.feature
@@ -16,3 +16,10 @@ Feature: Manage a user account
     When I press "Delete" for "damien" profile
     Then I should see "The user has been deleted"
     And I should see the users "freya and lilith"
+
+  Scenario: I can delete a user
+    Given I am on "admin"
+    When I stop following redirections
+    And I press "Delete" for "damien" profile
+    Then I should get a confirmation email with subject "Account deletion"
+    And I start following redirections

--- a/src/UserBundle/spec/EventSubscriber/MailerSubscriberSpec.php
+++ b/src/UserBundle/spec/EventSubscriber/MailerSubscriberSpec.php
@@ -1,0 +1,82 @@
+<?php
+
+/*
+ * This file is part of CarcelUserBundle.
+ *
+ * Copyright (c) 2016 Damien Carcel <damien.carcel@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace spec\Carcel\Bundle\UserBundle\EventSubscriber;
+
+use Carcel\Bundle\UserBundle\Event\UserEvents;
+use Carcel\Bundle\UserBundle\EventSubscriber\MailerSubscriber;
+use Carcel\Bundle\UserBundle\Manager\MailManager;
+use FOS\UserBundle\Model\UserInterface;
+use PhpSpec\ObjectBehavior;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\EventDispatcher\GenericEvent;
+
+/**
+ * @author Damien Carcel (damien.carcel@gmail.com)
+ */
+class MailerSubscriberSpec extends ObjectBehavior
+{
+    function let(MailManager $mailManager)
+    {
+        $this->beConstructedWith($mailManager);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(MailerSubscriber::class);
+    }
+
+    function it_is_an_event_subscriber()
+    {
+        $this->shouldImplement(EventSubscriberInterface::class);
+    }
+
+    function it_subscribes_to_user_remove_events()
+    {
+        $this->getSubscribedEvents()->shouldReturn([
+            UserEvents::PRE_REMOVE  => 'getUserEmail',
+            UserEvents::POST_REMOVE => 'sendMessage',
+        ]);
+    }
+
+    function it_gets_user_mail_address_and_username(
+        GenericEvent $event,
+        UserInterface $user
+    ) {
+        $event->getSubject()->willReturn($user);
+
+        $user->getEmail()->shouldBeCalled();
+        $user->getUsername()->shouldBeCalled();
+
+        $this->getUserEmail($event);
+    }
+
+    function it_throws_an_exception_if_subject_is_not_a_user(GenericEvent $event)
+    {
+        $event->getSubject()->willReturn('foobar');
+
+        $this->shouldThrow(
+            new \InvalidArgumentException('MailerSubscriber event is expected to contain an instance of User')
+        )->during('getUserEmail', [$event]);
+    }
+
+    function it_sends_an_email_to_a_user($mailManager)
+    {
+        $mailManager->send(
+            null,
+            null,
+            'carcel_user.mail.remove.subject',
+            'carcel_user.mail.remove.body'
+        )->shouldBeCalled();
+
+        $this->sendMessage();
+    }
+}

--- a/src/UserBundle/spec/Manager/MailManagerSpec.php
+++ b/src/UserBundle/spec/Manager/MailManagerSpec.php
@@ -14,7 +14,6 @@ namespace spec\Carcel\Bundle\UserBundle\Manager;
 use Carcel\Bundle\UserBundle\Factory\SwiftMessageFactory;
 use Carcel\Bundle\UserBundle\Manager\MailManager;
 use PhpSpec\ObjectBehavior;
-use Symfony\Component\Templating\EngineInterface;
 use Symfony\Component\Translation\TranslatorInterface;
 
 /**
@@ -24,11 +23,10 @@ class MailManagerSpec extends ObjectBehavior
 {
     function let(
         \Swift_Mailer $mailer,
-        EngineInterface $templating,
         TranslatorInterface $translator,
         SwiftMessageFactory $messageFactory
     ) {
-        $this->beConstructedWith($mailer, $templating, $translator, $messageFactory, 'noresponse@example.info');
+        $this->beConstructedWith($mailer, $translator, $messageFactory, 'noresponse@example.info');
     }
 
     function it_is_initializable()
@@ -37,25 +35,24 @@ class MailManagerSpec extends ObjectBehavior
     }
 
     function it_sends_a_mail_to_a_user(
-        $templating,
         $mailer,
         $translator,
         $messageFactory,
         \Swift_Message $message
     ) {
         $messageFactory->create()->willReturn($message);
-        $translator->trans('carcel_user.account.remove')->willReturn('Message subject');
-        $templating
-            ->render('CarcelUserBundle:Admin:email.txt.twig', ['username' => 'username'])
-            ->willReturn('Message body');
+        $translator->trans('carcel_user.remove.subject')->willReturn('Message subject');
+        $translator
+            ->trans('carcel_user.remove.content', ['username' => 'user name'])
+            ->willReturn('Message body for user name');
 
         $message->setSubject('Message subject')->willReturn($message);
         $message->setFrom('noresponse@example.info')->willReturn($message);
         $message->setTo('user@exemple.info')->willReturn($message);
-        $message->setBody('Message body')->willReturn($message);
+        $message->setBody('Message body for user name')->willReturn($message);
 
         $mailer->send($message)->shouldBeCalled();
 
-        $this->send('user@exemple.info', 'username');
+        $this->send('user@exemple.info', 'user name', 'carcel_user.remove.subject', 'carcel_user.remove.content');
     }
 }

--- a/src/UserBundle/spec/Manager/MailManagerSpec.php
+++ b/src/UserBundle/spec/Manager/MailManagerSpec.php
@@ -40,11 +40,11 @@ class MailManagerSpec extends ObjectBehavior
         $messageFactory,
         \Swift_Message $message
     ) {
-        $messageFactory->create()->willReturn($message);
-        $translator->trans('carcel_user.remove.subject')->willReturn('Message subject');
+        $translator->trans('mail.subject')->willReturn('Message subject');
         $translator
-            ->trans('carcel_user.remove.content', ['username' => 'user name'])
+            ->trans('mail.body', ['%username%' => 'user name'])
             ->willReturn('Message body for user name');
+        $messageFactory->create()->willReturn($message);
 
         $message->setSubject('Message subject')->willReturn($message);
         $message->setFrom('noresponse@example.info')->willReturn($message);
@@ -53,6 +53,6 @@ class MailManagerSpec extends ObjectBehavior
 
         $mailer->send($message)->shouldBeCalled();
 
-        $this->send('user@exemple.info', 'user name', 'carcel_user.remove.subject', 'carcel_user.remove.content');
+        $this->send('user@exemple.info', 'user name', 'mail.subject', 'mail.body');
     }
 }

--- a/src/UserBundle/src/Controller/AdminController.php
+++ b/src/UserBundle/src/Controller/AdminController.php
@@ -194,7 +194,12 @@ class AdminController extends Controller
                 $this->get('translator')->trans('carcel_user.notice.delete.label')
             );
 
-            $this->get('carcel_user.manager.mail')->send($email, $username);
+            $this->get('carcel_user.manager.mail')->send(
+                $email,
+                $username,
+                'carcel_user.remove.subject',
+                'carcel_user.mail.remove.content'
+            );
         }
 
         return $this->redirect($this->generateUrl('carcel_user_admin_index'));

--- a/src/UserBundle/src/Controller/AdminController.php
+++ b/src/UserBundle/src/Controller/AdminController.php
@@ -11,10 +11,11 @@
 
 namespace Carcel\Bundle\UserBundle\Controller;
 
-use Carcel\Bundle\UserBundle\Entity\Repository\UserRepositoryInterface;
+use Carcel\Bundle\UserBundle\Event\UserEvents;
 use Carcel\Bundle\UserBundle\Form\Factory\UserFormFactoryInterface;
 use FOS\UserBundle\Model\UserInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Component\EventDispatcher\GenericEvent;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -90,7 +91,12 @@ class AdminController extends Controller
 
         if ($form->isValid()) {
             $selectedRole = $form->getData();
+
+            $this->get('event_dispatcher')->dispatch(UserEvents::PRE_SET_ROLE, new GenericEvent($user));
+
             $userManager->setRole($user, $selectedRole);
+
+            $this->get('event_dispatcher')->dispatch(UserEvents::POST_SET_ROLE, new GenericEvent($user));
 
             $this->addFlash(
                 'notice',
@@ -151,7 +157,11 @@ class AdminController extends Controller
         $form->handleRequest($request);
 
         if ($form->isValid()) {
+            $this->get('event_dispatcher')->dispatch(UserEvents::PRE_UPDATE, new GenericEvent($user));
+
             $this->get('doctrine.orm.entity_manager')->flush();
+
+            $this->get('event_dispatcher')->dispatch(UserEvents::POST_UPDATE, new GenericEvent($user));
 
             $this->addFlash(
                 'notice',
@@ -183,22 +193,16 @@ class AdminController extends Controller
         $form->handleRequest($request);
 
         if ($form->isValid()) {
-            $email = $user->getEmail();
+            $this->get('event_dispatcher')->dispatch(UserEvents::PRE_REMOVE, new GenericEvent($user));
 
-            $entityManager = $this->get('doctrine.orm.entity_manager');
-            $entityManager->remove($user);
-            $entityManager->flush();
+            $this->get('doctrine.orm.entity_manager')->remove($user);
+            $this->get('doctrine.orm.entity_manager')->flush();
+
+            $this->get('event_dispatcher')->dispatch(UserEvents::POST_REMOVE);
 
             $this->addFlash(
                 'notice',
                 $this->get('translator')->trans('carcel_user.notice.delete.label')
-            );
-
-            $this->get('carcel_user.manager.mail')->send(
-                $email,
-                $username,
-                'carcel_user.remove.subject',
-                'carcel_user.mail.remove.content'
             );
         }
 
@@ -219,7 +223,10 @@ class AdminController extends Controller
      */
     protected function findUserByUsernameOr404($username)
     {
-        $user = $this->getUserRepository()->findOneBy(['username' => $username]);
+        $user = $this
+            ->get('doctrine.orm.entity_manager')
+            ->getRepository('CarcelUserBundle:User')
+            ->findOneBy(['username' => $username]);
 
         if (!$this->getUser()->isSuperAdmin() && $user->isSuperAdmin()) {
             throw $this->createAccessDeniedException();
@@ -233,14 +240,6 @@ class AdminController extends Controller
         }
 
         return $user;
-    }
-
-    /**
-     * @return UserRepositoryInterface
-     */
-    protected function getUserRepository()
-    {
-        return $this->get('doctrine.orm.entity_manager')->getRepository('CarcelUserBundle:User');
     }
 
     /**

--- a/src/UserBundle/src/DependencyInjection/CarcelUserExtension.php
+++ b/src/UserBundle/src/DependencyInjection/CarcelUserExtension.php
@@ -29,6 +29,7 @@ class CarcelUserExtension extends Extension
     public function load(array $configs, ContainerBuilder $container)
     {
         $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
+        $loader->load('event_subscribers.yml');
         $loader->load('factories.yml');
         $loader->load('form_factories.yml');
         $loader->load('form_types.yml');

--- a/src/UserBundle/src/Event/UserEvents.php
+++ b/src/UserBundle/src/Event/UserEvents.php
@@ -1,0 +1,78 @@
+<?php
+
+/*
+ * This file is part of CarcelUserBundle.
+ *
+ * Copyright (c) 2016 Damien Carcel <damien.carcel@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Carcel\Bundle\UserBundle\Event;
+
+/**
+ * @author Damien Carcel (damien.carcel@gmail.com)
+ */
+class UserEvents
+{
+    /**
+     * This event is dispatched just before a user is updated.
+     *
+     * The event listener receives a
+     * Symfony\Component\EventDispatcher\GenericEvent instance.
+     *
+     * @const string
+     */
+    const PRE_UPDATE = 'carcel_user.event.pre_update';
+
+    /**
+     * This event is dispatched just after a user is updated.
+     *
+     * The event listener receives a
+     * Symfony\Component\EventDispatcher\GenericEvent instance.
+     *
+     * @const string
+     */
+    const POST_UPDATE = 'carcel_user.event.post_update';
+
+    /**
+     * This event is dispatched just before a user is removed.
+     *
+     * The event listener receives a
+     * Symfony\Component\EventDispatcher\GenericEvent instance.
+     *
+     * @const string
+     */
+    const PRE_REMOVE = 'carcel_user.event.pre_remove';
+
+    /**
+     * This event is dispatched just after a user is removed.
+     *
+     * The event listener receives a
+     * Symfony\Component\EventDispatcher\GenericEvent instance.
+     *
+     * @const string
+     */
+    const POST_REMOVE = 'carcel_user.event.post_remove';
+
+    /**
+     * This event is dispatched just before the role of a user is changed.
+     *
+     * The event listener receives a
+     * Symfony\Component\EventDispatcher\GenericEvent instance.
+     *
+     * @const string
+     */
+    const PRE_SET_ROLE = 'carcel_user.event.pre_set_role';
+
+    /**
+     * This event is dispatched just after the role of a user is changed.
+     *
+     * The event listener receives a
+     * Symfony\Component\EventDispatcher\GenericEvent instance.
+     *
+     * @const string
+     */
+    const POST_SET_ROLE = 'carcel_user.event.post_set_role';
+}

--- a/src/UserBundle/src/EventSubscriber/MailerSubscriber.php
+++ b/src/UserBundle/src/EventSubscriber/MailerSubscriber.php
@@ -1,0 +1,84 @@
+<?php
+
+/*
+ * This file is part of CarcelUserBundle.
+ *
+ * Copyright (c) 2016 Damien Carcel <damien.carcel@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Carcel\Bundle\UserBundle\EventSubscriber;
+
+use Carcel\Bundle\UserBundle\Event\UserEvents;
+use Carcel\Bundle\UserBundle\Manager\MailManager;
+use FOS\UserBundle\Model\UserInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\EventDispatcher\GenericEvent;
+
+/**
+ * Subscriber that sends email to a user when its account has been removed.
+ *
+ * @author Damien Carcel (damien.carcel@gmail.com)
+ */
+class MailerSubscriber implements EventSubscriberInterface
+{
+    /** @var string */
+    protected $mailAddress;
+
+    /** @var MailManager */
+    protected $mailManager;
+
+    /** @var string */
+    protected $username;
+
+    /**
+     * @param MailManager $mailManager
+     */
+    public function __construct(MailManager $mailManager)
+    {
+        $this->mailManager = $mailManager;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function getSubscribedEvents()
+    {
+        return [
+            UserEvents::PRE_REMOVE  => 'getUserEmail',
+            UserEvents::POST_REMOVE => 'sendMessage',
+        ];
+    }
+
+    /**
+     * Gets the username and mail address of the user to be removed.
+     *
+     * @param GenericEvent $event
+     */
+    public function getUserEmail(GenericEvent $event)
+    {
+        $user = $event->getSubject();
+
+        if (!$user instanceof UserInterface) {
+            throw new \InvalidArgumentException('MailerSubscriber event is expected to contain an instance of User');
+        }
+
+        $this->mailAddress = $user->getEmail();
+        $this->username = $user->getUsername();
+    }
+
+    /**
+     * Sends an email to the removed user.
+     */
+    public function sendMessage()
+    {
+        $this->mailManager->send(
+            $this->mailAddress,
+            $this->username,
+            'carcel_user.mail.remove.subject',
+            'carcel_user.mail.remove.body'
+        );
+    }
+}

--- a/src/UserBundle/src/Manager/MailManager.php
+++ b/src/UserBundle/src/Manager/MailManager.php
@@ -12,7 +12,6 @@
 namespace Carcel\Bundle\UserBundle\Manager;
 
 use Carcel\Bundle\UserBundle\Factory\SwiftMessageFactory;
-use Symfony\Component\Templating\EngineInterface;
 use Symfony\Component\Translation\TranslatorInterface;
 
 /**
@@ -31,27 +30,21 @@ class MailManager
     /** @var SwiftMessageFactory */
     protected $messageFactory;
 
-    /** @var EngineInterface */
-    protected $templating;
-
     /** @var TranslatorInterface */
     protected $translator;
 
     /**
      * @param \Swift_Mailer       $mailer
-     * @param EngineInterface     $templating
      * @param TranslatorInterface $translator
      * @param SwiftMessageFactory $messageFactory
      * @param string              $mailerAddress
      */
     public function __construct(
         \Swift_Mailer $mailer,
-        EngineInterface $templating,
         TranslatorInterface $translator,
         SwiftMessageFactory $messageFactory,
         $mailerAddress
     ) {
-        $this->templating = $templating;
         $this->mailer = $mailer;
         $this->translator = $translator;
         $this->messageFactory = $messageFactory;
@@ -61,21 +54,23 @@ class MailManager
     /**
      * Sends an email.
      *
-     * @param string $email
+     * @param string $mailAddress
      * @param string $username
+     * @param string $subject
+     * @param string $content
      *
      * @return int The number of successful recipients. Can be 0 which indicates failure
      */
-    public function send($email, $username)
+    public function send($mailAddress, $username, $subject, $content)
     {
         $message = $this->messageFactory->create();
         $message
-            ->setSubject($this->translator->trans('carcel_user.account.remove'))
+            ->setSubject($this->translator->trans($subject))
             ->setFrom($this->mailerAddress)
-            ->setTo($email)
+            ->setTo($mailAddress)
             ->setBody(
-                $this->templating->render(
-                    'CarcelUserBundle:Admin:email.txt.twig',
+                $this->translator->trans(
+                    $content,
                     ['username' => $username]
                 )
             );

--- a/src/UserBundle/src/Manager/MailManager.php
+++ b/src/UserBundle/src/Manager/MailManager.php
@@ -57,23 +57,24 @@ class MailManager
      * @param string $mailAddress
      * @param string $username
      * @param string $subject
-     * @param string $content
+     * @param string $body
      *
      * @return int The number of successful recipients. Can be 0 which indicates failure
      */
-    public function send($mailAddress, $username, $subject, $content)
+    public function send($mailAddress, $username, $subject, $body)
     {
+        $subject = $this->translator->trans($subject);
+        $body = $this->translator->trans(
+            $body,
+            ['%username%' => $username]
+        );
+
         $message = $this->messageFactory->create();
         $message
-            ->setSubject($this->translator->trans($subject))
+            ->setSubject($subject)
             ->setFrom($this->mailerAddress)
             ->setTo($mailAddress)
-            ->setBody(
-                $this->translator->trans(
-                    $content,
-                    ['username' => $username]
-                )
-            );
+            ->setBody($body);
 
         return $this->mailer->send($message);
     }

--- a/src/UserBundle/src/Resources/config/event_subscribers.yml
+++ b/src/UserBundle/src/Resources/config/event_subscribers.yml
@@ -1,0 +1,7 @@
+services:
+    carcel_user.event.subscriber.mailer:
+        class: Carcel\Bundle\UserBundle\EventSubscriber\MailerSubscriber
+        arguments:
+            - '@carcel_user.manager.mail'
+        tags:
+            - { name: kernel.event_subscriber }

--- a/src/UserBundle/src/Resources/config/managers.yml
+++ b/src/UserBundle/src/Resources/config/managers.yml
@@ -6,7 +6,6 @@ services:
         class: Carcel\Bundle\UserBundle\Manager\MailManager
         arguments:
             - '@mailer'
-            - '@templating'
             - '@translator'
             - '@carcel_user.factory.swift_message'
             - '%carcel_user_mailer_address%'

--- a/src/UserBundle/src/Resources/translations/messages.en.yml
+++ b/src/UserBundle/src/Resources/translations/messages.en.yml
@@ -1,5 +1,4 @@
 carcel_user:
-    account.remove: Account deletion
     admin:
         edit.title: Edit user %name% profile
         index:
@@ -26,8 +25,9 @@ carcel_user:
         email.label: Email address
         role.label: Roles
     mail:
-        content:
-            remove: |
+        remove:
+            subject: Account deletion
+            content: |
                 Hello %username%.
 
                 Your user account is now removed.

--- a/src/UserBundle/src/Resources/translations/messages.en.yml
+++ b/src/UserBundle/src/Resources/translations/messages.en.yml
@@ -27,7 +27,7 @@ carcel_user:
     mail:
         remove:
             subject: Account deletion
-            content: |
+            body: |
                 Hello %username%.
 
                 Your user account is now removed.

--- a/src/UserBundle/src/Resources/translations/messages.fr.yml
+++ b/src/UserBundle/src/Resources/translations/messages.fr.yml
@@ -27,7 +27,7 @@ carcel_user:
     mail:
         remove:
             subject: Suppression de compte
-            content: |
+            body: |
                 Bonjour %username%.
 
                 Votre compte utilisateur a été supprimée.

--- a/src/UserBundle/src/Resources/translations/messages.fr.yml
+++ b/src/UserBundle/src/Resources/translations/messages.fr.yml
@@ -1,5 +1,4 @@
 carcel_user:
-    account.remove: Suppression de compte
     admin:
         edit.title: Édition du profil de l'utilisateur %name%
         index:
@@ -26,8 +25,9 @@ carcel_user:
         email.label: Adresse e-mail
         role.label: Roles
     mail:
-        content:
-            remove: |
+        remove:
+            subject: Suppression de compte
+            content: |
                 Bonjour %username%.
 
                 Votre compte utilisateur a été supprimée.

--- a/src/UserBundle/src/Resources/views/Admin/email.txt.twig
+++ b/src/UserBundle/src/Resources/views/Admin/email.txt.twig
@@ -1,1 +1,0 @@
-{{ 'carcel_user.mail.content.remove'|trans }}

--- a/var/SymfonyRequirements.php
+++ b/var/SymfonyRequirements.php
@@ -681,10 +681,17 @@ class SymfonyRequirements extends RequirementCollection
 
             if (class_exists('Symfony\Component\Intl\Intl')) {
                 $this->addRecommendation(
-                    \Symfony\Component\Intl\Intl::getIcuDataVersion() === \Symfony\Component\Intl\Intl::getIcuVersion(),
-                    sprintf('intl ICU version installed on your system (%s) should match the ICU data bundled with Symfony (%s)', \Symfony\Component\Intl\Intl::getIcuVersion(), \Symfony\Component\Intl\Intl::getIcuDataVersion()),
-                    'In most cases you should be fine, but please verify there is no inconsistencies between data provided by Symfony and the intl extension. See https://github.com/symfony/symfony/issues/15007 for an example of inconsistencies you might run into.'
+                    \Symfony\Component\Intl\Intl::getIcuDataVersion() <= \Symfony\Component\Intl\Intl::getIcuVersion(),
+                    sprintf('intl ICU version installed on your system is outdated (%s) and does not match the ICU data bundled with Symfony (%s)', \Symfony\Component\Intl\Intl::getIcuVersion(), \Symfony\Component\Intl\Intl::getIcuDataVersion()),
+                    'To get the latest internationalization data upgrade the ICU system package and the intl PHP extension.'
                 );
+                if (\Symfony\Component\Intl\Intl::getIcuDataVersion() <= \Symfony\Component\Intl\Intl::getIcuVersion()) {
+                    $this->addRecommendation(
+                        \Symfony\Component\Intl\Intl::getIcuDataVersion() === \Symfony\Component\Intl\Intl::getIcuVersion(),
+                        sprintf('intl ICU version installed on your system (%s) does not match the ICU data bundled with Symfony (%s)', \Symfony\Component\Intl\Intl::getIcuVersion(), \Symfony\Component\Intl\Intl::getIcuDataVersion()),
+                        'To avoid internationalization data incosistencies upgrade the symfony/intl component.'
+                    );
+                }
             }
 
             $this->addPhpIniRecommendation(


### PR DESCRIPTION
- [x] Remove mail template and use directly translation keys
- [x] Send removal confirmation through an event subscriber (add pre and post events on udpate, set role and remove actions)
- [x] Add functional tests on email sending
