### PR TITLE
Set Bundle requirements to Symfony ^3.0

### DIFF
--- a/src/UserBundle/composer.json
+++ b/src/UserBundle/composer.json
@@ -21,8 +21,8 @@
         "doctrine/orm": "^2.5",
         "doctrine/doctrine-bundle": "^1.6",
         "doctrine/doctrine-fixtures-bundle": "^2.3",
-        "symfony/framework-bundle": "^3.2",
-        "symfony/translation": "^3.2",
+        "symfony/framework-bundle": "^3.0",
+        "symfony/translation": "^3.0",
         "symfony/swiftmailer-bundle": "^2.3",
         "friendsofsymfony/user-bundle": "v2.0.0-beta1"
     },


### PR DESCRIPTION
Dev application specifically requires Symfony 3.2, but Bundle can accept every Symfony 3 minor versions.