### PR TITLE
Remove phpunit dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,6 @@
         "friendsofphp/php-cs-fixer": "^1.11",
         "phpmd/phpmd": "^2.4",
         "phpspec/phpspec": "^3.0",
-        "phpunit/phpunit": "^5.4",
         "squizlabs/php_codesniffer": "^2.5"
     },
     "scripts": {

--- a/src/UserBundle/composer.json
+++ b/src/UserBundle/composer.json
@@ -30,7 +30,6 @@
         "friendsofphp/php-cs-fixer": "^1.11",
         "phpmd/phpmd": "^2.4",
         "phpspec/phpspec": "^3.0",
-        "phpunit/phpunit": "^5.4",
         "squizlabs/php_codesniffer": "^2.5"
     },
     "config": {


### PR DESCRIPTION
Needed for behat tests.

Maybe phpunit assertions should be replaced, so phpunit can be dropped.