### PR TITLE
Closes #56 - Add GitHub PR and issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,11 @@
+| Q                  | A
+| ------------------ | -----
+| Bug report?        | yes/no
+| Feature request?   | yes/no
+| BC Break report?   | yes/no
+| RFC?               | yes/no
+| UserBundle version | x.y.z
+
+<!--
+- Please replace this comment by the description of your issue.
+-->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,23 @@
+## Description
+
+<!--
+- Please fill in this template according to the PR you're about to submit.
+- Replace this comment by a description of what your PR is solving.
+- Bug fixes must be submitted against the lowest branch where they apply
+  (lowest branches are regularly merged to upper ones so they get the fixes too).
+- Features and deprecations must be submitted against the master branch.
+-->
+
+## Definition Of Done
+| Q                                 | A
+| --------------------------------- | ---
+| Added Specs                       | Todo
+| Added Behats                      | Todo
+| Changelog updated                 | Todo
+| Migration script                  | -
+| Documentation                     | -
+| Fixed tickets                     | #... <!-- #-prefixed issue number(s), if any -->
+
+`Todo`: Pending / Work in progress
+`OK`: Done / Validated
+`-`: Not needed

--- a/behat.yml.dist
+++ b/behat.yml.dist
@@ -5,12 +5,6 @@ default:
                 default:
                     symfony2: ~
         Behat\Symfony2Extension: ~
-        BehatExtension\DoctrineDataFixturesExtension\Extension:
-            lifetime: scenario
-            autoload: false
-            directories: ~
-            fixtures:
-                - Carcel\Bundle\UserBundle\DataFixtures\ORM\LoadUserData
     suites:
         default:
             contexts:

--- a/composer.json
+++ b/composer.json
@@ -23,12 +23,13 @@
         ]
     },
     "require": {
+        "php": ">=5.6",
         "doctrine/orm": "^2.5",
         "doctrine/doctrine-bundle": "^1.6",
         "doctrine/doctrine-cache-bundle": "^1.2",
         "doctrine/doctrine-fixtures-bundle": "^2.3",
         "incenteev/composer-parameter-handler": "^2.0",
-        "friendsofsymfony/user-bundle": "v2.0.0-beta1",
+        "friendsofsymfony/user-bundle": "v2.0.0-beta2",
         "sensio/distribution-bundle": "^5.0",
         "sensio/framework-extra-bundle": "^3.0.2",
         "symfony/monolog-bundle": "^3.0",

--- a/composer.json
+++ b/composer.json
@@ -23,34 +23,32 @@
         ]
     },
     "require": {
-        "php": ">=5.5.9",
-        "symfony/symfony": "3.2.*",
         "doctrine/orm": "^2.5",
         "doctrine/doctrine-bundle": "^1.6",
         "doctrine/doctrine-cache-bundle": "^1.2",
         "doctrine/doctrine-fixtures-bundle": "^2.3",
-        "symfony/swiftmailer-bundle": "^2.3",
-        "symfony/monolog-bundle": "^3.0",
-        "symfony/polyfill-apcu": "^1.0",
+        "incenteev/composer-parameter-handler": "^2.0",
+        "friendsofsymfony/user-bundle": "v2.0.0-beta1",
         "sensio/distribution-bundle": "^5.0",
         "sensio/framework-extra-bundle": "^3.0.2",
-        "incenteev/composer-parameter-handler": "^2.0",
-        "friendsofsymfony/user-bundle": "v2.0.0-beta1"
+        "symfony/monolog-bundle": "^3.0",
+        "symfony/polyfill-apcu": "^1.0",
+        "symfony/swiftmailer-bundle": "^2.3",
+        "symfony/symfony": "3.2.*"
     },
     "require-dev": {
-        "sensio/generator-bundle": "^3.0",
-        "symfony/phpunit-bridge": "^3.0",
         "behat/behat": "^3.1",
         "behat/mink": "^1.7",
         "behat/mink-extension": "^2.2",
         "behat/mink-browserkit-driver": "^1.3",
         "behat/symfony2-extension": "^2.1",
-        "behat-extension/doctrine-data-fixtures-extension": "^4.0",
         "friendsofphp/php-cs-fixer": "^1.11",
         "phpmd/phpmd": "^2.4",
         "phpspec/phpspec": "^3.0",
         "phpunit/phpunit": "^5.4",
-        "squizlabs/php_codesniffer": "^2.5"
+        "sensio/generator-bundle": "^3.0",
+        "squizlabs/php_codesniffer": "^2.5",
+        "symfony/phpunit-bridge": "^3.0"
     },
     "scripts": {
         "symfony-scripts": [

--- a/features/administrators/delete.feature
+++ b/features/administrators/delete.feature
@@ -1,3 +1,4 @@
+@fixtures
 Feature: Delete a user account
   In order to administrate user accounts
   As an administrator
@@ -10,7 +11,7 @@ Feature: Delete a user account
     And I fill in "Username" with "aurore"
     And I fill in "Password" with "aurore"
     And I press "Log in"
-
+  @fixtures
   Scenario: I can delete a user
     Given I am on "admin"
     When I press "Delete" for "damien" profile

--- a/features/administrators/edit.feature
+++ b/features/administrators/edit.feature
@@ -1,3 +1,4 @@
+@fixtures
 Feature: Edit user profiles
   In order to administrate user accounts
   As an administrator

--- a/features/administrators/list.feature
+++ b/features/administrators/list.feature
@@ -1,3 +1,4 @@
+@fixtures
 Feature: Manage user accounts
   In order to administrate user accounts
   As an administrator

--- a/features/administrators/roles.feature
+++ b/features/administrators/roles.feature
@@ -1,3 +1,4 @@
+@fixtures
 Feature: Change users roles
   In order to administrate user accounts
   As an administrator

--- a/features/administrators/status.feature
+++ b/features/administrators/status.feature
@@ -1,3 +1,4 @@
+@fixtures
 Feature: Change users status
   In order to administrate user accounts
   As an administrator

--- a/features/administrators/super_administrator.feature
+++ b/features/administrators/super_administrator.feature
@@ -1,3 +1,4 @@
+@fixtures
 Feature: Administrate administrators
   In order to administrate users including administrators
   As the super administrator

--- a/features/administrators/view.feature
+++ b/features/administrators/view.feature
@@ -1,3 +1,4 @@
+@fixtures
 Feature: See user profiles
   In order to administrate user accounts
   As an administrator

--- a/features/anonymous/authentication.feature
+++ b/features/anonymous/authentication.feature
@@ -1,3 +1,4 @@
+@fixtures
 Feature: Authenticate users
   In order to authenticate myself
   As an anonymous user

--- a/features/anonymous/creation.feature
+++ b/features/anonymous/creation.feature
@@ -1,3 +1,4 @@
+@fixtures
 Feature: Create account
   In order to access the application
   As an anonymous user

--- a/features/anonymous/resetting.feature
+++ b/features/anonymous/resetting.feature
@@ -1,3 +1,4 @@
+@fixtures
 Feature: Reset password
   In order to access the application
   As an anonymous user

--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -17,7 +17,10 @@ use Behat\Symfony2Extension\Context\KernelAwareContext;
 use Behat\Symfony2Extension\Driver\KernelDriver;
 use Carcel\Bundle\UserBundle\Entity\Repository\UserRepositoryInterface;
 use Carcel\Bundle\UserBundle\Manager\UserManager;
+use Doctrine\Common\DataFixtures\Executor\ORMExecutor;
+use Doctrine\Common\DataFixtures\Purger\ORMPurger;
 use FOS\UserBundle\Model\UserManagerInterface;
+use Symfony\Bridge\Doctrine\DataFixtures\ContainerAwareLoader as DataFixturesLoader;
 use Symfony\Component\BrowserKit\Client;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Symfony\Component\HttpKernel\KernelInterface;
@@ -54,6 +57,21 @@ class FeatureContext extends MinkContext implements KernelAwareContext
     public function setKernel(KernelInterface $kernel)
     {
         $this->kernel = $kernel;
+    }
+
+    /**
+     * @BeforeScenario @fixtures
+     */
+    public function loadFixtures()
+    {
+        $entityManager = $this->kernel->getContainer()->get('doctrine.orm.entity_manager');
+
+        $loader = new DataFixturesLoader($this->kernel->getContainer());
+        $loader->loadFromFile($this->kernel->getRootDir().'/../src/UserBundle/src/DataFixtures/ORM/LoadUserData.php');
+
+        $purger = new ORMPurger($entityManager);
+        $executor = new ORMExecutor($entityManager, $purger);
+        $executor->execute($loader->getFixtures());
     }
 
     /**

--- a/features/users/profile.feature
+++ b/features/users/profile.feature
@@ -1,3 +1,4 @@
+@fixtures
 Feature: Manage a user account
   In order to manage my user account
   As a user

--- a/src/UserBundle/composer.json
+++ b/src/UserBundle/composer.json
@@ -21,10 +21,10 @@
         "doctrine/orm": "^2.5",
         "doctrine/doctrine-bundle": "^1.6",
         "doctrine/doctrine-fixtures-bundle": "^2.3",
+        "friendsofsymfony/user-bundle": "v2.0.0-beta2",
         "symfony/framework-bundle": "^3.0",
         "symfony/translation": "^3.0",
-        "symfony/swiftmailer-bundle": "^2.3",
-        "friendsofsymfony/user-bundle": "v2.0.0-beta1"
+        "symfony/swiftmailer-bundle": "^2.3"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^1.11",


### PR DESCRIPTION
## Description

This PR:
- adds GitHub templates for new pull requests and new issues
- update to FOS user bundle 2.0 beta 1
- remove `behat-extension/doctrine-data-fixtures-extension `

## Definition Of Done
| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Changelog updated                 | -
| Migration script                  | -
| Documentation                     | -
| Fixed tickets                     | #56 and #61

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
