### PR TITLE
Issue-61: Fix bad php-cs-fixer configuration

### DIFF
--- a/docker-compose.yml.dist
+++ b/docker-compose.yml.dist
@@ -6,7 +6,9 @@ services:
     depends_on:
       - mysql
     environment:
+      PHP_IDE_CONFIG: 'serverName=user-bundle-cli'
       PHP_XDEBUG_ENABLED: 0
+      XDEBUG_CONFIG: 'remote_host=xxx.xxx.xxx.xxx'
     user: docker
     volumes:
       - ./:/home/docker/symfony
@@ -19,6 +21,8 @@ services:
     image: carcel/nginx
     depends_on:
       - fpm
+    environment:
+      PHP_IDE_CONFIG: 'serverName=user-bundle'
     ports:
       - '8080:80'
     volumes:

--- a/src/UserBundle/.php_cs.php
+++ b/src/UserBundle/.php_cs.php
@@ -26,6 +26,5 @@ return PhpCsFixer\Config::create()
     ->setFinder(
         PhpCsFixer\Finder::create()
             ->name('*.php')
-            ->in(__DIR__.'/features')
             ->in(__DIR__.'/src')
     );


### PR DESCRIPTION
## Description

`UserBundle` php-cs-fixer configuration was looking for a `features` folder. This resulted in a failure, as this folder is only present in the development application.

## Definition Of Done
| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Changelog updated                 | -
| Migration script                  | -
| Documentation                     | -
| Fixed tickets                     | #61

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
