### PR TITLE
Update `docker-compose.yml.dist`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@
 /bin/*
 !/bin/console
 !/bin/symfony_requirements
+/docker/*
+!/docker/nginx.conf
+!/docker/upload.conf
 /var/*
 !/var/cache
 /var/cache/*
@@ -18,4 +21,5 @@
 /web/bundles/
 behat.yml
 composer.lock
+docker-compose.yml
 .php_cs.cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ install:
     - bower update
 
 script:
-    - bin/phpcs -p --standard=PSR2 --extensions=php src/UserBundle/src
-    - bin/php-cs-fixer fix --dry-run -v --diff --config=.php_cs.php
-    - bin/behat src/UserBundle/features
-    - cd src/UserBundle && composer update --prefer-dist --no-interaction --no-scripts && bin/phpspec run
+    - vendor/bin/phpcs -p --standard=PSR2 --extensions=php src/UserBundle/src
+    - vendor/bin/php-cs-fixer fix --dry-run -v --diff --config=.php_cs.php
+    - vendor/bin/behat src/UserBundle/features
+    - cd src/UserBundle && composer update --prefer-dist --no-interaction --no-scripts && vendor/bin/phpspec run

--- a/composer.json
+++ b/composer.json
@@ -69,7 +69,7 @@
         ]
     },
     "config": {
-        "bin-dir": "bin",
+        "bin-dir": "vendor/bin",
         "platform": {
             "php": "7.1"
         },

--- a/docker-compose.yml.dist
+++ b/docker-compose.yml.dist
@@ -2,23 +2,24 @@ version: '2'
 
 services:
   fpm:
-    image: carcel/fpm:7.1
+    image: akeneo/fpm:7.1
     depends_on:
       - mysql
     environment:
+      COMPOSER_HOME: /home/docker/.composer
       PHP_IDE_CONFIG: 'serverName=user-bundle-cli'
       PHP_XDEBUG_ENABLED: 0
       XDEBUG_CONFIG: 'remote_host=xxx.xxx.xxx.xxx'
     user: docker
     volumes:
-      - ./:/home/docker/application
+      - ./:/srv/application
       - ~/.composer:/home/docker/.composer
-    working_dir: /home/docker/application
+    working_dir: /srv/application
     networks:
       - user-bundle
 
   nginx:
-    image: carcel/nginx
+    image: nginx
     depends_on:
       - fpm
     environment:
@@ -26,7 +27,9 @@ services:
     ports:
       - '8080:80'
     volumes:
-      - ./:/home/docker/application
+      - ./:/srv/application
+      - ./docker/nginx.conf:/etc/nginx/conf.d/default.conf
+      - ./docker/upload.conf:/etc/nginx/conf.d/upload.conf
     networks:
       - user-bundle
 
@@ -37,6 +40,8 @@ services:
       - MYSQL_USER=user_bundle
       - MYSQL_PASSWORD=user_bundle
       - MYSQL_DATABASE=user_bundle
+    ports:
+      - '3306:3306'
     networks:
       - user-bundle
 

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -1,0 +1,33 @@
+server {
+    listen      80;
+    server_name user-bundle.dev;
+    root        /srv/application/web;
+
+    location / {
+        try_files $uri /app.php$is_args$args;
+    }
+
+    location ~ ^/(app_dev|config)\.php(/|$) {
+        fastcgi_pass            fpm:9001;
+        fastcgi_split_path_info ^(.+\.php)(/.*)$;
+        include                 fastcgi_params;
+        fastcgi_param           SCRIPT_FILENAME $realpath_root$fastcgi_script_name;
+        fastcgi_param           DOCUMENT_ROOT   $realpath_root;
+    }
+
+    location ~ ^/app\.php(/|$) {
+        fastcgi_pass            akeneo:9001;
+        fastcgi_split_path_info ^(.+\.php)(/.*)$;
+        include                 fastcgi_params;
+        fastcgi_param           SCRIPT_FILENAME $realpath_root$fastcgi_script_name;
+        fastcgi_param           DOCUMENT_ROOT   $realpath_root;
+        internal;
+    }
+
+    location ~ \.php$ {
+        return 404;
+    }
+
+    error_log  /var/log/nginx/user-bundle_error.log;
+    access_log /var/log/nginx/user-bundle_access.log;
+}

--- a/docker/upload.conf
+++ b/docker/upload.conf
@@ -1,0 +1,1 @@
+client_max_body_size 20m;

--- a/src/UserBundle/.travis.yml
+++ b/src/UserBundle/.travis.yml
@@ -20,6 +20,6 @@ install:
     - composer update --prefer-dist --no-interaction --no-scripts
 
 script:
-    - bin/phpcs -p --standard=PSR2 --extensions=php src
-    - bin/php-cs-fixer fix --dry-run -v --diff --config=.php_cs.php
-    - bin/phpspec run
+    - vendor/bin/phpcs -p --standard=PSR2 --extensions=php src
+    - vendor/bin/php-cs-fixer fix --dry-run -v --diff --config=.php_cs.php
+    - vendor/bin/phpspec run

--- a/src/UserBundle/composer.json
+++ b/src/UserBundle/composer.json
@@ -36,7 +36,7 @@
         "squizlabs/php_codesniffer": "^2.5"
     },
     "config": {
-        "bin-dir": "bin",
+        "bin-dir": "vendor/bin",
         "platform": {
             "php": "7.1"
         },


### PR DESCRIPTION
## Description

`carcel` docker images have been recently transfered to `akeneo`. This PR update the compose file to use them, and use official `nginx` image instead of `carcel/nginx`.

Vendors binaries are also linked in `vendor/bin` instead of `bin`, as it is recommended by Symfony.

## Definition Of Done

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Changelog updated                 | -
| Migration script                  | -
| Documentation                     | -
| Fixed tickets                     | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
