### PR TITLE
Issue 75: Install and use bower locally with npm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 /docker/*
 !/docker/nginx.conf
 !/docker/upload.conf
+/node_modules
 /var/*
 !/var/cache
 /var/cache/*
@@ -19,7 +20,8 @@
 /vendor/
 /web/assets/
 /web/bundles/
-behat.yml
-composer.lock
-docker-compose.yml
-.php_cs.cache
+/behat.yml
+/composer.lock
+/docker-compose.yml
+/package-lock.json
+/.php_cs.cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,8 +23,8 @@ install:
     - mysql -e 'CREATE DATABASE symfony;'
     - bin/console doctrine:schema:update --force --env=test > /dev/null
     - bin/console assets:install
-    - npm install -g bower
-    - bower update
+    - npm install
+    - npm run assets
 
 script:
     - vendor/bin/phpcs -p --standard=PSR2 --extensions=php src/UserBundle/src

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.2.2 (2017-07-23)
+
+## Enhancements
+
+- **Issue 75**: Install and use bower locally through npm.
+
 # 0.2.1 (2017-06-04)
 
 ## Enhancements

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ If you encountered a bug or miss a functionality, don't hesitate to raise an iss
 
 ## Requirements
 
-- PHP 5.6+
+- PHP 7.1+
 - PHP Modules:
     - apcu
     - curl
@@ -33,21 +33,35 @@ If you encountered a bug or miss a functionality, don't hesitate to raise an iss
     - intl
     - mysql
     - mcrypt
-- MySQL 5.1 and above or MariaDB
+- MySQL or MariaDB
 
 ## Installation
 
+The following part assume the use of Docker and Docker Compose. However, the same commands (without the Docker part) can be used on a local environment.
+
 ### Download and install from GitHub
 
-If you didn't, start by [installing composer](https://getcomposer.org/download/). You also need to prepare a MySQL database.
+Just clone the repository, the copy the file `docker-compose.yml.dist` by removing the `.dist` extension.
 
-Just clone the repository, and install dependencies by running `php composer.phar update`. Composer will ask you for your application configuration (database name, user and password).
-
-Then you can populate this database with a basic set of [doctrine fixtures](https://symfony.com/doc/current/bundles/DoctrineFixturesBundle/index.html) provided by the bundle (or create your own, of course):
+Up the containers by running 
 
 ```bash
-bin/console doctrine:schema:update --force
-bin/console doctrine:fixtures:load
+docker-compose up -d
+```
+
+and install dependencies with
+
+```bash
+docker-compose exec fpm composer update
+```
+
+Composer will ask you for your application configuration (database name, user and password).
+
+You can now populate this database with a basic set of [doctrine fixtures](https://symfony.com/doc/current/bundles/DoctrineFixturesBundle/index.html) provided by the bundle (or create your own, of course):
+
+```bash
+docker-compose exec fpm bin/console doctrine:schema:update --force
+docker-compose exec fpm bin/console doctrine:fixtures:load
 ```
 
 ### Deploy the assets
@@ -55,19 +69,11 @@ bin/console doctrine:fixtures:load
 Run the following command:
 
 ```bash
-bin/console assets:install
-bower update
+docker-compose exec fpm bin/console assets:install --symlink
+docker-compose run node npm run assets
 ```
 
-### Run the application
-
-The application is now ready to run. You can either configure a HTTP server of your choice (Apache, nginx…) or use the Symfony internal server:
-
-```bash
-bin/console server:run
-```
-
-You should now be able to display the login page (your.application.domain.name/login).
+You should now be able to access the application and login with `localhost:8080/login`.
 
 ## License
 

--- a/app/config/security.yml
+++ b/app/config/security.yml
@@ -33,6 +33,7 @@ security:
                 csrf_token_generator: security.csrf.token_manager
                 use_referer: true
                 use_forward: true
+                always_use_default_target_path: true
             logout:
                 path: fos_user_security_logout
                 target: /

--- a/docker-compose.yml.dist
+++ b/docker-compose.yml.dist
@@ -1,6 +1,16 @@
 version: '2'
 
 services:
+  node:
+    image: node:8
+    user: node
+    volumes:
+      - ./:/srv/application
+      - ~/.npm:/home/node/.npm
+    working_dir: /srv/application
+    networks:
+      - user-bundle
+
   fpm:
     image: akeneo/fpm:7.1
     depends_on:

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -16,7 +16,7 @@ server {
     }
 
     location ~ ^/app\.php(/|$) {
-        fastcgi_pass            akeneo:9001;
+        fastcgi_pass            fpm:9001;
         fastcgi_split_path_info ^(.+\.php)(/.*)$;
         include                 fastcgi_params;
         fastcgi_param           SCRIPT_FILENAME $realpath_root$fastcgi_script_name;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "user-bundle-dev",
-  "version": "0.2.0",
+  "version": "0.2.2",
   "description": "Development application for CarcelUserBundle",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "user-bundle-dev",
+  "version": "0.2.0",
+  "description": "Development application for CarcelUserBundle",
+  "main": "index.js",
+  "scripts": {
+    "assets": "node_modules/.bin/bower update"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/damien-carcel/user-bundle-dev.git"
+  },
+  "keywords": [
+    "User",
+    "management"
+  ],
+  "author": {
+    "name": "Damien Carcel",
+    "email": "damien.carcel@gmail.com"
+  },
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/damien-carcel/user-bundle-dev/issues"
+  },
+  "homepage": "https://github.com/damien-carcel/user-bundle-dev#readme",
+  "dependencies": {
+    "bower": "^1.8.0"
+  }
+}

--- a/src/UserBundle/CHANGELOG.md
+++ b/src/UserBundle/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.2.2 (2017-07-23)
+
+## Enhancements
+
+- **Issue 75**: Install and use bower locally through npm.
+
 # 0.2.1 (2017-06-04)
 
 ## Enhancements

--- a/src/UserBundle/README.md
+++ b/src/UserBundle/README.md
@@ -1,5 +1,6 @@
 # CarcelUserBundle
 
+[![SensioLabsInsight](https://insight.sensiolabs.com/projects/bb2956c2-e172-4169-baf7-2f59c74400cd/mini.png)](https://insight.sensiolabs.com/projects/bb2956c2-e172-4169-baf7-2f59c74400cd)
 [![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/damien-carcel/UserBundle/badges/quality-score.png?b=0.2)](https://scrutinizer-ci.com/g/damien-carcel/UserBundle/?branch=0.2)
 [![Build Status](https://travis-ci.org/damien-carcel/UserBundle.svg?branch=0.2)](https://travis-ci.org/damien-carcel/UserBundle)
 
@@ -15,7 +16,7 @@ Please note this is a read-only repository. If you want to make a contribution (
 
 ## Requirements
 
-- PHP 5.6+
+- PHP 7.1+
 - PHP Modules:
     - apcu
     - curl
@@ -23,7 +24,7 @@ Please note this is a read-only repository. If you want to make a contribution (
     - intl
     - mysql
     - mcrypt
-- MySQL 5.1 and above or MariaDB
+- MySQL or MariaDB
 
 ## Installation and configuration
 

--- a/src/UserBundle/bower.json
+++ b/src/UserBundle/bower.json
@@ -1,12 +1,10 @@
 {
     "name": "carcel-user-bundle",
     "homepage": "https://github.com/damien-carcel/UserBundle",
-    "authors": [
-        {
-            "name": "Damien Carcel",
-            "homepage": "https://github.com/damien-carcel/"
-        }
-    ],
+    "author": {
+        "name": "Damien Carcel",
+        "homepage": "https://github.com/damien-carcel/"
+    },
     "description": "",
     "license": "MIT",
     "dependencies": {

--- a/src/UserBundle/features/administrators/list.feature
+++ b/src/UserBundle/features/administrators/list.feature
@@ -23,4 +23,5 @@ Feature: Manage user accounts
     And I fill in "Username" with "damien"
     And I fill in "Password" with "damien"
     When I press "Log in"
+    And I am on "admin/"
     Then I should see "403 Forbidden"

--- a/src/UserBundle/features/users/profile.feature
+++ b/src/UserBundle/features/users/profile.feature
@@ -55,8 +55,8 @@ Feature: Manage a user account
       | Username | damien  |
       | Password | pandore |
     And I press "Log in"
-    Then I should be on "profile/"
-    And I should see "Username: damien"
+    And I am on "profile/"
+    Then I should see "Username: damien"
 
   Scenario: I cannot change my password without knowing it
     Given I am on "profile/"


### PR DESCRIPTION
## Description

Use `npm` package manager to install and run `bower` (no need to install it globally anymore).
The compose file template is updated according too.

This PR also sets the security option `always_use_default_target_path` to true.

## Definition Of Done

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | OK
| Changelog updated                 | OK
| Migration script                  | -
| Documentation                     | -
| Fixed tickets                     | #75

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
