### PR TITLE
Closes #78 - Update phpspec, phpunit and php-codesniffer

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ docker-compose exec fpm bin/console doctrine:fixtures:load
 Run the following command:
 
 ```bash
-docker-compose exec fpm bin/console assets:install --symlink
+docker-compose exec fpm bin/console assets:install --symlink  --relative
 docker-compose run node npm run assets
 ```
 

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
         "symfony/polyfill-apcu": "^1.0",
         "symfony/swiftmailer-bundle": "^2.3.10",
         "symfony/symfony": "3.3.*",
-        "twig/twig": "^1.0||^2.0"
+        "twig/twig": "^2.0"
     },
     "require-dev": {
         "behat/behat": "^3.1",
@@ -46,10 +46,10 @@
         "behat-extension/doctrine-data-fixtures-extension": "^4.0",
         "friendsofphp/php-cs-fixer": "^2.0",
         "phpmd/phpmd": "^2.4",
-        "phpspec/phpspec": "^3.0",
-        "phpunit/phpunit": "^5.4",
+        "phpspec/phpspec": "^4.0",
+        "phpunit/phpunit": "^6.0",
         "sensio/generator-bundle": "^3.0",
-        "squizlabs/php_codesniffer": "^2.5",
+        "squizlabs/php_codesniffer": "^3.0",
         "symfony/phpunit-bridge": "^3.0"
     },
     "scripts": {

--- a/src/UserBundle/composer.json
+++ b/src/UserBundle/composer.json
@@ -24,16 +24,16 @@
         "doctrine/orm": "^2.5",
         "friendsofsymfony/user-bundle": "^2.0",
         "symfony/framework-bundle": "^3.0",
+        "symfony/swiftmailer-bundle": "^2.3",
         "symfony/translation": "^3.0",
-        "twig/twig": "^1.0||^2.0",
-        "symfony/swiftmailer-bundle": "^2.3"
+        "twig/twig": "^2.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.0",
         "phpmd/phpmd": "^2.4",
-        "phpspec/phpspec": "^3.0",
-        "phpunit/phpunit": "^5.4",
-        "squizlabs/php_codesniffer": "^2.5"
+        "phpspec/phpspec": "^4.0",
+        "phpunit/phpunit": "^6.0",
+        "squizlabs/php_codesniffer": "^3.0"
     },
     "config": {
         "bin-dir": "vendor/bin",

--- a/src/UserBundle/features/bootstrap/UserBundleFeatureContext.php
+++ b/src/UserBundle/features/bootstrap/UserBundleFeatureContext.php
@@ -19,6 +19,7 @@ use Behat\Symfony2Extension\Driver\KernelDriver;
 use Carcel\Bundle\UserBundle\Entity\Repository\UserRepositoryInterface;
 use Carcel\Bundle\UserBundle\Manager\UserManager;
 use FOS\UserBundle\Model\UserManagerInterface;
+use PHPUnit\Framework\Assert;
 use Symfony\Component\BrowserKit\Client;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Symfony\Component\HttpKernel\KernelInterface;
@@ -72,7 +73,7 @@ class UserBundleFeatureContext extends MinkContext implements KernelAwareContext
             throw new TokenNotFoundException();
         }
 
-        \PHPUnit_Framework_Assert::assertEquals($token->getUsername(), $username);
+        Assert::assertEquals($token->getUsername(), $username);
     }
 
     /**
@@ -85,8 +86,8 @@ class UserBundleFeatureContext extends MinkContext implements KernelAwareContext
     {
         $checker = $this->getAuthorizationChecker();
 
-        \PHPUnit_Framework_Assert::assertTrue($checker->isGranted('IS_AUTHENTICATED_ANONYMOUSLY'));
-        \PHPUnit_Framework_Assert::assertFalse($checker->isGranted('ROLE_USER'));
+        Assert::assertTrue($checker->isGranted('IS_AUTHENTICATED_ANONYMOUSLY'));
+        Assert::assertFalse($checker->isGranted('ROLE_USER'));
     }
 
     /**
@@ -124,7 +125,7 @@ class UserBundleFeatureContext extends MinkContext implements KernelAwareContext
         }
         sort($userNames);
 
-        \PHPUnit_Framework_Assert::assertEquals($providedUserNames, $userNames);
+        Assert::assertEquals($providedUserNames, $userNames);
     }
 
     /**
@@ -142,7 +143,7 @@ class UserBundleFeatureContext extends MinkContext implements KernelAwareContext
         $row = $this->findUserRowByText($username);
         $link = $row->findLink($action);
 
-        \PHPUnit_Framework_Assert::assertNotNull($link, 'Cannot find link in row with text '.$action);
+        Assert::assertNotNull($link, 'Cannot find link in row with text '.$action);
         $link->click();
     }
 
@@ -161,7 +162,7 @@ class UserBundleFeatureContext extends MinkContext implements KernelAwareContext
         $row = $this->findUserRowByText($username);
         $button = $row->findButton($action);
 
-        \PHPUnit_Framework_Assert::assertNotNull($button, 'Cannot find button in row with text '.$action);
+        Assert::assertNotNull($button, 'Cannot find button in row with text '.$action);
         $button->press();
     }
 
@@ -176,7 +177,7 @@ class UserBundleFeatureContext extends MinkContext implements KernelAwareContext
     public function userShouldHaveRole($username, $role)
     {
         $user = $this->getUserRepository()->findOneBy(['username' => $username]);
-        \PHPUnit_Framework_Assert::assertTrue($user->hasRole($role));
+        Assert::assertTrue($user->hasRole($role));
     }
 
     /**
@@ -205,12 +206,12 @@ class UserBundleFeatureContext extends MinkContext implements KernelAwareContext
     {
         $collector = $this->getSymfonyProfile()->getCollector('swiftmailer');
 
-        \PHPUnit_Framework_Assert::assertEquals(1, $collector->getMessageCount());
+        Assert::assertEquals(1, $collector->getMessageCount());
 
         $messages = $collector->getMessages();
         $message = $messages[0];
 
-        \PHPUnit_Framework_Assert::assertEquals($subject, $message->getSubject());
+        Assert::assertEquals($subject, $message->getSubject());
     }
 
     /**
@@ -282,7 +283,7 @@ class UserBundleFeatureContext extends MinkContext implements KernelAwareContext
     {
         $user = $this->getUserRepository()->findOneBy(['username' => $username]);
 
-        \PHPUnit_Framework_Assert::assertTrue($status === $user->isEnabled());
+        Assert::assertTrue($status === $user->isEnabled());
     }
 
     /**
@@ -334,7 +335,7 @@ class UserBundleFeatureContext extends MinkContext implements KernelAwareContext
     {
         $row = $this->getSession()->getPage()->find('css', sprintf('table tr:contains("%s")', $username));
 
-        \PHPUnit_Framework_Assert::assertNotNull($row, 'Cannot find a table row with username '.$username);
+        Assert::assertNotNull($row, 'Cannot find a table row with username '.$username);
 
         return $row;
     }


### PR DESCRIPTION
## Description

Use new major versions: phpspec 4.0, phpunit 6.0 and php-codesniffer 3.0.

## Definition Of Done

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Changelog updated                 | -
| Migration script                  | -
| Documentation                     | -
| Fixed tickets                     | #78

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
