### PR TITLE
Fix array key/value alignement in php-cs-fixer

### DIFF
--- a/src/UserBundle/.php_cs.php
+++ b/src/UserBundle/.php_cs.php
@@ -2,30 +2,32 @@
 
 return PhpCsFixer\Config::create()
     ->setRiskyAllowed(true)
-    ->setRules([
-        '@PSR2'                                 => true,
-        '@Symfony'                              => true,
-        '@Symfony:risky'                        => true,
-        'array_syntax'                          => ['syntax' => 'short'],
-        'binary_operator_spaces'                => [
-            'align_double_arrow' => true,
-            'align_equals'       => false,
-        ],
-        'concat_space'                          => ['spacing' => 'none'],
-        'linebreak_after_opening_tag'           => true,
-        'no_unreachable_default_argument_value' => true,
-        'no_useless_else'                       => true,
-        'no_useless_return'                     => true,
-        'ordered_class_elements'                => true,
-        'ordered_imports'                       => true,
-        'phpdoc_add_missing_param_annotation'   => true,
-        'phpdoc_order'                          => true,
-        'psr4'                                  => true,
-        'semicolon_after_instruction'           => true,
-    ])
+    ->setRules(
+        [
+            '@PSR2' => true,
+            '@Symfony' => true,
+            '@Symfony:risky' => true,
+            'array_syntax' => ['syntax' => 'short'],
+            'binary_operator_spaces' => [
+                'align_double_arrow' => false,
+                'align_equals' => false,
+            ],
+            'concat_space' => ['spacing' => 'none'],
+            'linebreak_after_opening_tag' => true,
+            'no_unreachable_default_argument_value' => true,
+            'no_useless_else' => true,
+            'no_useless_return' => true,
+            'ordered_class_elements' => true,
+            'ordered_imports' => true,
+            'phpdoc_add_missing_param_annotation' => true,
+            'phpdoc_order' => true,
+            'psr4' => true,
+            'semicolon_after_instruction' => true,
+        ]
+    )
     ->setFinder(
         PhpCsFixer\Finder::create()
             ->name('*.php')
-            ->in(__DIR__.'/features')
-            ->in(__DIR__.'/src')
+            ->in(__DIR__ . '/features')
+            ->in(__DIR__ . '/src')
     );


### PR DESCRIPTION
## Definition Of Done

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Changelog updated                 | -
| Migration script                  | -
| Documentation                     | -
| Fixed tickets                     | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
